### PR TITLE
build:storybook fails when "extract css" is enable

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const server = require('@storybook/core/server');
 const VueLoaderPlugin = require('vue-loader/lib/plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 const wrapDefaultConfig = config => ({
   ...config,
@@ -15,7 +16,7 @@ module.exports = (api, projectOptions) => {
 
   const wrapInitialConfig = config => ({
     ...config,
-    plugins: [...config.plugins, new VueLoaderPlugin()],
+    plugins: [...config.plugins, new VueLoaderPlugin(), new MiniCssExtractPlugin()],
     module: {
       ...config.module,
       ...resolvedConfig.module,


### PR DESCRIPTION
Plugin fails when I try to build the storybook, the error reported is:

![image](https://user-images.githubusercontent.com/750002/44159388-8378ee00-a0b7-11e8-83af-940d64b4f197.png)

Webpack storybook config needs to load the `MiniCssExtractPlugin` to work, one time the plugin is added the build works perfectly and the CSS is extracted.

About css extract on vue (not included on vue-loader) https://vue-loader.vuejs.org/guide/extract-css.html#webpack-4