### PR TITLE
Remove pwa plugin from chainable webpack config

### DIFF
--- a/lib/wrapInitialConfig.js
+++ b/lib/wrapInitialConfig.js
@@ -7,6 +7,7 @@ module.exports = (api) => {
   chain.plugins.delete('copy');
   chain.plugins.delete('preload');
   chain.plugins.delete('prefetch');
+  chain.plugins.delete('pwa');
 
   const resolvedConfig = chain.toConfig();
 


### PR DESCRIPTION
Hello!
There is fix for this error which caused by PWA plugin:

```
yarn run serve:storybook
yarn run v1.9.4
$ vue-cli-service serve:storybook -p 6006 -c config/storybook
info @storybook/vue v4.0.0-alpha.20
info
info => Loading custom addons config.
info => Using default webpack setup.
  0% compiling  0% compiling ERROR  TypeError: Cannot read property 'tapAsync' of undefined
TypeError: Cannot read property 'tapAsync' of undefined
    at compiler.hooks.compilation.tap.compilation (./node_modules/@vue/cli-plugin-pwa/lib/HtmlPwaPlugin.js:30:63)
    at SyncHook.eval [as call] (eval at create (./node_modules/tapable/lib/HookCodeFactory.js:17:12), <anonymous>:25:1)
    at SyncHook.lazyCompileHook [as _call] (./node_modules/tapable/lib/Hook.js:35:21)
    at Compiler.newCompilation (./node_modules/webpack/lib/Compiler.js:504:26)
    at hooks.beforeCompile.callAsync.err (./node_modules/webpack/lib/Compiler.js:540:29)
    at AsyncSeriesHook.eval [as callAsync] (eval at create (./node_modules/tapable/lib/HookCodeFactory.js:24:12), <anonymous>:6:1)
    at AsyncSeriesHook.lazyCompileHook [as _callAsync] (./node_modules/tapable/lib/Hook.js:35:21)
    at Compiler.compile (./node_modules/webpack/lib/Compiler.js:535:28)
    at compiler.hooks.watchRun.callAsync.err (./node_modules/webpack/lib/Watching.js:77:18)
    at AsyncSeriesHook.eval [as callAsync] (eval at create (./node_modules/tapable/lib/HookCodeFactory.js:24:12), <anonymous>:24:1)
    at AsyncSeriesHook.lazyCompileHook [as _callAsync] (./node_modules/tapable/lib/Hook.js:35:21)
    at Watching._go (./node_modules/webpack/lib/Watching.js:40:32)
    at Watching.compiler.readRecords.err (./node_modules/webpack/lib/Watching.js:32:9)
    at Compiler.readRecords (./node_modules/webpack/lib/Compiler.js:402:11)
    at new Watching (./node_modules/webpack/lib/Watching.js:29:17)
    at Compiler.watch (./node_modules/webpack/lib/Compiler.js:201:10)
error Command failed with exit code 1.
```

I assume that PWA plugin is unnecessary for storybook