### PR TITLE
Add define plugin in allowed plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,9 @@ const wrapDefaultConfig = config => ({
 });
 
 // eslint-disable-next-line no-unused-vars
-module.exports = (api, projectOptions) => {
+module.exports = (api, { pluginOptions }) => {
+  const options = Object.assign({}, pluginOptions && pluginOptions.storybook);
+
   api.registerCommand('serve:storybook', {
     description: 'Start storybook',
     usage: 'vue-cli-service serve:storybook',
@@ -33,7 +35,7 @@ module.exports = (api, projectOptions) => {
         name: '@storybook/vue',
         version: '4.0.0-alpha.20',
       },
-      wrapInitialConfig: wrapInitialConfig(api),
+      wrapInitialConfig: wrapInitialConfig(api, options),
       wrapDefaultConfig,
     });
   });
@@ -53,7 +55,7 @@ module.exports = (api, projectOptions) => {
         name: '@storybook/vue',
         version: '4.0.0-alpha.20',
       },
-      wrapInitialConfig: wrapInitialConfig(api),
+      wrapInitialConfig: wrapInitialConfig(api, options),
       wrapDefaultConfig,
     });
   });

--- a/lib/wrapInitialConfig.js
+++ b/lib/wrapInitialConfig.js
@@ -1,15 +1,23 @@
-module.exports = (api) => {
+module.exports = (api, options) => {
   const chain = api.resolveChainableWebpackConfig();
   const existingPlugins = chain.plugins.values().map(item => item.name);
-  const allowedPlugins = [
+  let allowedPlugins = [
     'vue-loader',
     'friendly-errors',
     'no-emit-on-errors',
     'extract-css',
     'optimize-css',
     'hash-module-ids',
-    'define',
   ];
+
+  if (options && options.allowedPlugins) {
+    allowedPlugins = options.allowedPlugins.reduce((allPlugins, plugin) => {
+      if (allPlugins.indexOf(plugin) < 0) {
+        allPlugins.push(plugin);
+      }
+      return allPlugins;
+    }, allowedPlugins);
+  }
 
   existingPlugins.forEach((plugin) => {
     if (!allowedPlugins.includes(plugin)) {

--- a/lib/wrapInitialConfig.js
+++ b/lib/wrapInitialConfig.js
@@ -8,6 +8,7 @@ module.exports = (api) => {
     'extract-css',
     'optimize-css',
     'hash-module-ids',
+    'define',
   ];
 
   existingPlugins.forEach((plugin) => {


### PR DESCRIPTION
Hello!
I added `define` plugin in the `allowedPlugins` and here is why:
In `vue.config.js` I added `definePlugin` to pass some env variables (hosts, etc.), but since this plugin isn't allowed, my env variables became undefined. This can be solved by adding plugin in custom webpack config, specified in `config/storybook/webpack.config.js`, but keeping the same logic in two different places seems to be wrong.