### PR TITLE
Respect `configureWebpack` option in vue.config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ However, storybook will filter all the plugins for webpack according to internal
 }
 ```
 
-Note that only plugins defined with [webpack-chain](https://cli.vuejs.org/guide/webpack.html#chaining-advanced) config can be used in storybook.
+Note that only plugins defined with [webpack-chain](https://cli.vuejs.org/guide/webpack.html#chaining-advanced) config can be filtered using the `allowedPlugins` option. Plugings defined through `configureWebpack` will always be included in the final webpack config.
 
 ## Contributors
 Here is a list of [Contributors](http://github.com/storybooks/vue-cli-plugin-storybook/contributors)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ However, storybook will filter all the plugins for webpack according to internal
 }
 ```
 
+Note that only plugins defined with [webpack-chain](https://cli.vuejs.org/guide/webpack.html#chaining-advanced) config can be used in storybook.
+
 ## Contributors
 Here is a list of [Contributors](http://github.com/storybooks/vue-cli-plugin-storybook/contributors)
 

--- a/preset.js
+++ b/preset.js
@@ -1,7 +1,7 @@
 module.exports = {
   webpack: (config, { api, options }) => {
-    const chain = api.resolveChainableWebpackConfig();
-    const existingPlugins = chain.plugins.values().map(item => item.name);
+    const chainConfig = api.resolveChainableWebpackConfig();
+    const existingPlugins = chainConfig.plugins.values().map(item => item.name);
     const allowedPlugins = [
       'vue-loader',
       'friendly-errors',
@@ -13,27 +13,28 @@ module.exports = {
 
     existingPlugins.forEach((plugin) => {
       if (!allowedPlugins.includes(plugin) && !options.allowedPlugins.includes(plugin)) {
-        chain.plugins.delete(plugin);
+        chainConfig.plugins.delete(plugin);
       }
     });
 
-    const resolvedConfig = chain.toConfig();
+    const resolvedChain = chainConfig.toConfig();
+    const webpackConfig = api.resolveWebpackConfig();
 
     return {
       ...config,
-      plugins: [...config.plugins, ...resolvedConfig.plugins],
+      plugins: [...config.plugins, ...resolvedChain.plugins],
       module: {
         ...config.module,
-        ...resolvedConfig.module,
+        ...webpackConfig.module,
       },
       resolve: {
-        ...resolvedConfig.resolve,
+        ...webpackConfig.resolve,
         alias: {
-          ...resolvedConfig.resolve.alias,
+          ...webpackConfig.resolve.alias,
           vue$: require.resolve('vue/dist/vue.esm.js'),
         },
       },
-      resolveLoader: resolvedConfig.resolveLoader,
+      resolveLoader: resolvedChain.resolveLoader,
     };
   },
   webpackFinal: config => ({

--- a/preset.js
+++ b/preset.js
@@ -29,7 +29,7 @@ module.exports = {
       resolve: {
         ...webpackConfig.resolve,
         alias: {
-          ...webpackConfig.resolve.alias,
+          ...webpackConfig.resolve && webpackConfig.resolve.alias,
           vue$: require.resolve('vue/dist/vue.esm.js'),
         },
       },

--- a/preset.js
+++ b/preset.js
@@ -17,12 +17,11 @@ module.exports = {
       }
     });
 
-    const resolvedChain = chainConfig.toConfig();
-    const webpackConfig = api.resolveWebpackConfig();
+    const webpackConfig = api.resolveWebpackConfig(chainConfig);
 
     return {
       ...config,
-      plugins: [...config.plugins, ...resolvedChain.plugins],
+      plugins: [...config.plugins, ...webpackConfig.plugins],
       module: {
         ...config.module,
         ...webpackConfig.module,
@@ -34,7 +33,7 @@ module.exports = {
           vue$: require.resolve('vue/dist/vue.esm.js'),
         },
       },
-      resolveLoader: resolvedChain.resolveLoader,
+      resolveLoader: webpackConfig.resolveLoader,
     };
   },
   webpackFinal: config => ({

--- a/preset.js
+++ b/preset.js
@@ -1,7 +1,7 @@
 module.exports = {
   webpack: (config, { api, options }) => {
-    const chainConfig = api.resolveChainableWebpackConfig();
-    const existingPlugins = chainConfig.plugins.values().map(item => item.name);
+    const chainableConfig = api.resolveChainableWebpackConfig();
+    const existingPlugins = chainableConfig.plugins.values().map(item => item.name);
     const allowedPlugins = [
       'vue-loader',
       'friendly-errors',
@@ -13,11 +13,11 @@ module.exports = {
 
     existingPlugins.forEach((plugin) => {
       if (!allowedPlugins.includes(plugin) && !options.allowedPlugins.includes(plugin)) {
-        chainConfig.plugins.delete(plugin);
+        chainableConfig.plugins.delete(plugin);
       }
     });
 
-    const webpackConfig = api.resolveWebpackConfig(chainConfig);
+    const webpackConfig = api.resolveWebpackConfig(chainableConfig);
 
     return {
       ...config,

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# TODO the tests should verify how the webpack configs are merged
+
 rm -rf tmp
 npm pack .
 npx vue create --preset test/preset.json tmp

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,4 +1,4 @@
-#!/#!/usr/bin/env bash
+#!/usr/bin/env bash
 
 rm -rf tmp
 npm pack .


### PR DESCRIPTION
Storybook currently does not pickup on config defined in `configureWebpack:`, only chained config defined through the chain-loader option. This PR changes that behaviour and uses `api.resolveWebpackConfig()` (which includes both config defined through both options in vue.config.js).

This makes it easier to work with storybook for users that define e.g aliases without using chain-loader.

Plugins are still filtered through chain-loader only because plain webpack config does not allow us to easily name plugins.

This closes #37 