### PR TITLE
Fix: Use storybook options given to the Vue Command

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,11 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const server = require('@storybook/core/server');
+const {
+  devOptions,
+  prodOptions,
+  generateVueCliOptions,
+  generateCommanderProgram,
+} = require('./options');
 
 const defaultOptions = {
   allowedPlugins: [],
@@ -12,19 +18,8 @@ module.exports = (api, { pluginOptions = {} }) => {
   api.registerCommand('storybook:serve', {
     description: 'Start storybook',
     usage: 'vue-cli-service storybook:serve',
-    options: {
-      '-p, --port [number]': 'Port to run Storybook (required)',
-      '-h, --host [string]': 'Host to run Storybook',
-      '-s, --static-dir <dir-names>': 'Directory where to load static files from',
-      '-c, --config-dir [dir-name]': 'Directory where to load Storybook configurations from',
-      '--https': 'Serve Storybook over HTTPS. Note: You must provide your own certificate information.',
-      '--ssl-ca <ca>': 'Provide an SSL certificate authority. (Optional with --https, required if using a self-signed certificate)',
-      '--ssl-cert <cert>': 'Provide an SSL certificate. (Required with --https)',
-      '--ssl-key <key>': 'Provide an SSL key. (Required with --https)',
-      '--smoke-test': 'Exit after successful start',
-      '--quiet': 'Suppress verbose build output',
-    },
-  }, () => {
+    options: generateVueCliOptions(devOptions),
+  }, (_, argv) => {
     server.buildDev({
       packageJson: {
         name: '@storybook/vue',
@@ -36,19 +31,15 @@ module.exports = (api, { pluginOptions = {} }) => {
           options: { api, options },
         },
       ],
+      ...generateCommanderProgram(argv, devOptions),
     });
   });
 
   api.registerCommand('storybook:build', {
     description: 'Build storybook',
     usage: 'vue-cli-service storybook:build',
-    options: {
-      '-s, --static-dir <dir-names>': 'Directory where to load static files from',
-      '-o, --output-dir [dir-name]': 'Directory where to store built files',
-      '-c, --config-dir [dir-name]': 'Directory where to load Storybook configurations from',
-      '-w, --watch': 'Enable watch mode (default: false)',
-    },
-  }, () => {
+    options: generateVueCliOptions(prodOptions),
+  }, (_, argv) => {
     server.buildStatic({
       packageJson: {
         name: '@storybook/vue',
@@ -60,6 +51,7 @@ module.exports = (api, { pluginOptions = {} }) => {
           options: { api, options },
         },
       ],
+      ...generateCommanderProgram(argv, prodOptions),
     });
   });
 };

--- a/options.js
+++ b/options.js
@@ -1,0 +1,53 @@
+const { Command } = require('commander');
+
+function parseList(str) {
+  return str.split(',');
+}
+
+// Parsed from storybook repo.
+// tags/v4.1.4: storybook/lib/core/src/server/cli/prod.js
+const prodOptions = [
+  ['-s, --static-dir <dir-names>', 'Directory where to load static files from', parseList],
+  ['-o, --output-dir [dir-name]', 'Directory where to store built files'],
+  ['-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from'],
+  ['-w, --watch', 'Enable watch mode'],
+];
+
+// Parsed from storybook repo.
+// tags/v4.1.4: storybook/lib/core/src/server/cli/dev.js
+const devOptions = [
+  ['-p, --port [number]', 'Port to run Storybook', str => parseInt(str, 10)],
+  ['-h, --host [string]', 'Host to run Storybook'],
+  ['-s, --static-dir <dir-names>', 'Directory where to load static files from', parseList],
+  ['-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from'],
+  ['--https', 'Serve Storybook over HTTPS. Note: You must provide your own certificate information.'],
+  ['--ssl-ca <ca>', 'Provide an SSL certificate authority. (Optional with --https, required if using a self-signed certificate)', parseList],
+  ['--ssl-cert <cert>', 'Provide an SSL certificate. (Required with --https)'],
+  ['--ssl-key <key>', 'Provide an SSL key. (Required with --https)'],
+  ['--smoke-test', 'Exit after successful start'],
+  ['--ci', "CI mode (skip interactive prompts, don't open browser"],
+  ['--quiet', 'Suppress verbose build output'],
+];
+
+const generateVueCliOptions = options => options.reduce(
+  (vueCliOptions, [arg, desc]) => ({ ...vueCliOptions, [arg]: desc }),
+  {},
+);
+
+const MOCK_EXECUTABLE_ARGV = ['node', 'vue-cli-plugin-storybook'];
+const generateCommanderProgram = (argv, options) => {
+  const program = new Command();
+
+  options.forEach(([arg, desc, transform]) => {
+    program.option(arg, desc, transform);
+  });
+  program.parse(MOCK_EXECUTABLE_ARGV.concat(argv));
+  return program;
+};
+
+module.exports = {
+  prodOptions,
+  devOptions,
+  generateCommanderProgram,
+  generateVueCliOptions,
+};

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "homepage": "https://github.com/storybooks/vue-cli-plugin-storybook#readme",
   "dependencies": {
     "@storybook/addons": "^4.1.0",
-    "@storybook/vue": "^4.1.0"
+    "@storybook/vue": "^4.1.0",
+    "commander": "^2.19.0"
   },
   "devDependencies": {
     "@vue/cli": "^3.2.0",


### PR DESCRIPTION
Previously these were inferred by storybook with the global `process.argv`.

This doesn't always work if the `storybook:serve|build` command is programatically called. To ensure storybook has them we should provide them when invoking the `buildDev` or `buildStatic` APIs.

I've opted to use the `command` package to create the options given to these APIs, because it's whats being used internally in Storybook; I guess it means we'll run into less edge cases.

Fixes #45.